### PR TITLE
Replace underscore dependency with lodash

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-var _ = require('underscore');
+var _ = require('lodash');
 
 /**
  * Read a list of versions an sort it.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/quentinrossetti/version-sort",
   "dependencies": {
-    "underscore": "^1.6.0"
+    "lodash": "^4.0.0"
   },
   "devDependencies": {
     "chai": "^1.9.1",

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 /* global describe, it */
 'use strict';
-var _      = require('underscore');
+var _      = require('lodash');
 var chai   = require('chai');
 var sorter = require('..');
 


### PR DESCRIPTION
This package happened to be useful for a problem I had, but underscore isn't used much anymore and it seems silly to drag the dependency in. Do you think we could replace the dependency with lodash? It's basically a drop-in change.