### PR TITLE
Allow to pass `null` values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDE
+.idea
+
 # Logs
 logs
 *.log
@@ -6,6 +9,7 @@ logs
 pids
 *.pid
 *.seed
+package-lock.json
 
 # Coverage directory used by tools like istanbul
 test/coverage

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ var results = sort(data, options);
    var results = sort(softwares, { nested: 'version' });
    // [ { version: '1.1alpha' }, { version: '1.1'} ]
    ```
+   
+ * `allow_null`: *(default: `false`)* Use this option to allow `null` values.
+    Example:
+    ```js
+    var results = sort([ '1.1', null ], { allow_null: true });
+       [ null, '1.1' ]
+    ```
 
 ## Installation
 

--- a/index.js
+++ b/index.js
@@ -15,13 +15,15 @@ module.exports = function (versions, opts) {
   // Options
   var options = {
     ignore_stages: false,
-    nested       : false
+    nested       : false,
+    allow_null   : false
   };
+
   if (opts) {
     options.ignore_stages = opts.ignore_stages || options.ignore_stages;
     options.nested = opts.nested || options.nested;
+    options.allow_null = opts.allow_null || options.allow_null;
   }
-
 
   // Nested objects
   if (options.nested) {
@@ -57,7 +59,7 @@ module.exports = function (versions, opts) {
 
   // Fill stores up!
   versions.forEach(function (_version) {
-    var compose = composeVersion(_version, regex);
+    var compose = composeVersion(_version, regex, options.allow_null);
     v.push(compose);
     store.number.push(compose.number);
     store.stage.push(compose.stage);
@@ -106,7 +108,7 @@ module.exports = function (versions, opts) {
   //TODO: commenting
   len.stageNumber = _.max(lenStore.stageNumber).toString().length;
 
-  
+
   var versionsSort = [];
 
   v.forEach(function (_version, _i) {
@@ -167,9 +169,16 @@ module.exports = function (versions, opts) {
 /**
  * Transform a string into an exploitable version object.
  * @param str The original string
+ * @param regex The regex applied
+ * @param allowNull Whether null values are accepted
  * @returns {{number: *, stage: (*|null), stageName: (*|null), stageNumber: (*|null)}}
  */
-function composeVersion(str, regex) {
+function composeVersion(str, regex, allowNull) {
+  if (allowNull){
+    str = str || 0;
+  } else if (str === null) {
+    throw new Error('To allow passing null values set the `allow_null` option as true.');
+  }
   var r = regex.exec(str);
   return {
     number     : r[ 1 ],

--- a/test/index.js
+++ b/test/index.js
@@ -51,4 +51,19 @@ describe('version-sorter module', function () {
     expect(r).to.eql(data);
   });
 
+  it('should throw error for null values', function () {
+    var data = [
+      null,
+      '1.1' ];
+    chai.assert.throws(function () { sorter(data);}, Error, 'To allow passing null values set the `allow_null` option as true.');
+  });
+
+  it('should allow for null values with `allow_null`', function () {
+    var data = [
+      null,
+      '1.1' ];
+    var r = sorter(_.shuffle(data), {allow_null: true});
+    expect(r).to.eql(data);
+  });
+
 });


### PR DESCRIPTION
Hi, using your package I has an issue while trying ordering an array containing `null` (unspecified) versions. With this PR a new Error is thrown for `null` values and the use of a `allow_null` option is suggested. `null` values are treated as version `0`.